### PR TITLE
Change for..in to for..of

### DIFF
--- a/services/report/app.js
+++ b/services/report/app.js
@@ -5,7 +5,7 @@ require('dotenv').config({ path: path.resolve(__dirname, '.env') })
 
 var report = {}
 async function updateReport(products) {
-    for(let product in products) {
+    for(let product of products) {
         if(!product.name) {
             continue
         } else if(!report[product.name]) {


### PR DESCRIPTION
Usando o for..of para fazer o loop corretamente no array de objetos, o for..in retorna os índices do array, ao invés do conteúdo.

Referência:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in